### PR TITLE
🐞 Bug fix: search url was not supported anymore

### DIFF
--- a/assets/js/geocoder.js
+++ b/assets/js/geocoder.js
@@ -369,7 +369,7 @@
     },
 
     geocode: function (query, cb, context) {
-      L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search/', L.extend({
+      L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search', L.extend({
           q: query,
           limit: 5,
           format: 'json',


### PR DESCRIPTION
Using the URL /search/ and /reverse/ (with slashes) is no longer supported by Leaflet library See https://github.com/osm-search/Nominatim/issues/3134 for more details.